### PR TITLE
feat: add an output `has_not_linked_commit` and improve the error message

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -52,12 +52,14 @@ runs:
             echo "has_not_linked_commit=true" >> "$GITHUB_OUTPUT"
             exit 1
           fi
+          echo "has_not_linked_commit=false" >> "$GITHUB_OUTPUT"
           echo "::error:: Approval is required from anyone who did not push commits to the pull request https://github.com/suzuki-shunsuke/deny-self-approve-action" >&2
           exit 1
         fi
         if grep -q "commit isn't linked to a GitHub User" "$tempfile"; then
           echo "::warning:: Commit isn't linked to a GitHub User. Please fix git config. https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user" >&2
           echo "has_not_linked_commit=true" >> "$GITHUB_OUTPUT"
+          exit 0
         fi
         echo "has_not_linked_commit=false" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,10 @@ inputs:
       Ignore commits not linked to a GitHub User.
     required: false
     default: "false"
+outputs:
+  has_not_linked_commit:
+    description: Whether there are commits not linked to a GitHub User
+    value: ${{ steps.deny.outputs.has_not_linked_commit }}
 runs:
   using: composite
   steps:
@@ -45,6 +49,7 @@ runs:
         if ! deny-self-approve $opts validate --dismiss 2> >(tee -a "$tempfile" >&2); then
           if grep -q "commit isn't linked to a GitHub User" "$tempfile"; then
             echo "::error:: Commit isn't linked to a GitHub User. Please fix git config. https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user" >&2
+            echo "has_not_linked_commit=true" >> "$GITHUB_OUTPUT"
             exit 1
           fi
           echo "::error:: Approval is required from anyone who did not push commits to the pull request https://github.com/suzuki-shunsuke/deny-self-approve-action" >&2
@@ -52,8 +57,11 @@ runs:
         fi
         if grep -q "commit isn't linked to a GitHub User" "$tempfile"; then
           echo "::warning:: Commit isn't linked to a GitHub User. Please fix git config. https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user" >&2
+          echo "has_not_linked_commit=true" >> "$GITHUB_OUTPUT"
         fi
+        echo "has_not_linked_commit=false" >> "$GITHUB_OUTPUT"
       shell: bash
+      id: deny
       env:
         AQUA_CONFIG: ${{ steps.aqua_config.outputs.value }}
         GITHUB_TOKEN: ${{github.token}}

--- a/action.yaml
+++ b/action.yaml
@@ -11,9 +11,9 @@ inputs:
       pull_requests:write - Dismiss approvals
       contents:read - List commits in pull requests
     required: false
-  ignore_unknown_commit:
+  ignore_not_linked_commit:
     description: |
-      Ignore unknown commits.
+      Ignore commits not linked to a GitHub User.
     required: false
     default: "false"
 runs:
@@ -57,4 +57,4 @@ runs:
       env:
         AQUA_CONFIG: ${{ steps.aqua_config.outputs.value }}
         GITHUB_TOKEN: ${{github.token}}
-        IGNORE: ${{inputs.ignore_unknown_commit}}
+        IGNORE: ${{inputs.ignore_not_linked_commit}}

--- a/action.yaml
+++ b/action.yaml
@@ -11,6 +11,11 @@ inputs:
       pull_requests:write - Dismiss approvals
       contents:read - List commits in pull requests
     required: false
+  ignore_unknown_commit:
+    description: |
+      Ignore unknown commits.
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -32,7 +37,11 @@ runs:
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
 
     - run: |
-        if ! deny-self-approve validate --dismiss; then
+        opts=""
+        if [ "$IGNORE" = "true" ]; then
+          opts="--ignore-unknown-commit"
+        fi
+        if ! deny-self-approve $opts validate --dismiss; then
           echo "::error:: Approval is required from anyone who did not push commits to the pull request https://github.com/suzuki-shunsuke/deny-self-approve-action" >&2
           exit 1
         fi
@@ -40,3 +49,4 @@ runs:
       env:
         AQUA_CONFIG: ${{ steps.aqua_config.outputs.value }}
         GITHUB_TOKEN: ${{github.token}}
+        IGNORE: ${{inputs.ignore_unknown_commit}}

--- a/action.yaml
+++ b/action.yaml
@@ -11,11 +11,6 @@ inputs:
       pull_requests:write - Dismiss approvals
       contents:read - List commits in pull requests
     required: false
-  ignore_not_linked_commit:
-    description: |
-      Ignore commits not linked to a GitHub User.
-    required: false
-    default: "false"
 outputs:
   has_not_linked_commit:
     description: Whether there are commits not linked to a GitHub User
@@ -41,30 +36,19 @@ runs:
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
 
     - run: |
-        opts=""
-        if [ "$IGNORE" = "true" ]; then
-          opts="--ignore-not-linked-commit"
-        fi
         tempfile=$(mktemp)
-        if ! deny-self-approve $opts validate --dismiss 2> >(tee -a "$tempfile" >&2); then
+        echo "has_not_linked_commit=false" >> "$GITHUB_OUTPUT"
+        if ! deny-self-approve validate --dismiss 2> >(tee -a "$tempfile" >&2); then
           if grep -q "commit isn't linked to a GitHub User" "$tempfile"; then
             echo "::error:: Commit isn't linked to a GitHub User. Please fix git config. https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user" >&2
             echo "has_not_linked_commit=true" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-          echo "has_not_linked_commit=false" >> "$GITHUB_OUTPUT"
           echo "::error:: Approval is required from anyone who did not push commits to the pull request https://github.com/suzuki-shunsuke/deny-self-approve-action" >&2
           exit 1
         fi
-        if grep -q "commit isn't linked to a GitHub User" "$tempfile"; then
-          echo "::warning:: Commit isn't linked to a GitHub User. Please fix git config. https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user" >&2
-          echo "has_not_linked_commit=true" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-        echo "has_not_linked_commit=false" >> "$GITHUB_OUTPUT"
       shell: bash
       id: deny
       env:
         AQUA_CONFIG: ${{ steps.aqua_config.outputs.value }}
         GITHUB_TOKEN: ${{github.token}}
-        IGNORE: ${{inputs.ignore_not_linked_commit}}

--- a/action.yaml
+++ b/action.yaml
@@ -51,7 +51,7 @@ runs:
           exit 1
         fi
         if grep -q "commit isn't linked to a GitHub User" "$tempfile"; then
-          echo "::warn:: Commit isn't linked to a GitHub User. Please fix git config. https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user" >&2
+          echo "::warning:: Commit isn't linked to a GitHub User. Please fix git config. https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user" >&2
         fi
       shell: bash
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -39,11 +39,19 @@ runs:
     - run: |
         opts=""
         if [ "$IGNORE" = "true" ]; then
-          opts="--ignore-unknown-commit"
+          opts="--ignore-not-linked-commit"
         fi
-        if ! deny-self-approve $opts validate --dismiss; then
+        tempfile=$(mktemp)
+        if ! deny-self-approve $opts validate --dismiss 2> >(tee -a "$tempfile" >&2); then
+          if grep -q "commit isn't linked to GitHub Users" "$tempfile"; then
+            echo "::error:: Commits aren't linked to GitHub Users. Please fix git config. https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user" >&2
+            exit 1
+          fi
           echo "::error:: Approval is required from anyone who did not push commits to the pull request https://github.com/suzuki-shunsuke/deny-self-approve-action" >&2
           exit 1
+        fi
+        if grep -q "commit isn't linked to GitHub Users" "$tempfile"; then
+          echo "::warn:: Commits aren't linked to GitHub Users. Please fix git config. https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user" >&2
         fi
       shell: bash
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -43,15 +43,15 @@ runs:
         fi
         tempfile=$(mktemp)
         if ! deny-self-approve $opts validate --dismiss 2> >(tee -a "$tempfile" >&2); then
-          if grep -q "commit isn't linked to GitHub Users" "$tempfile"; then
-            echo "::error:: Commits aren't linked to GitHub Users. Please fix git config. https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user" >&2
+          if grep -q "commit isn't linked to a GitHub User" "$tempfile"; then
+            echo "::error:: Commit isn't linked to a GitHub User. Please fix git config. https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user" >&2
             exit 1
           fi
           echo "::error:: Approval is required from anyone who did not push commits to the pull request https://github.com/suzuki-shunsuke/deny-self-approve-action" >&2
           exit 1
         fi
-        if grep -q "commit isn't linked to GitHub Users" "$tempfile"; then
-          echo "::warn:: Commits aren't linked to GitHub Users. Please fix git config. https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user" >&2
+        if grep -q "commit isn't linked to a GitHub User" "$tempfile"; then
+          echo "::warn:: Commit isn't linked to a GitHub User. Please fix git config. https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user" >&2
         fi
       shell: bash
       env:

--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -1,33 +1,33 @@
 {
   "checksums": [
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-0/deny-self-approve_darwin_amd64.tar.gz",
-      "checksum": "2B8C90B2FCEAC7E5D6E4B472CE33DD8298AA60AE4EEADDBEDE2EC045D93BDF59",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-1/deny-self-approve_darwin_amd64.tar.gz",
+      "checksum": "54C244A4E654F5331669770860F74AD5B63949821DF52A0D16199B49504D0A13",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-0/deny-self-approve_darwin_arm64.tar.gz",
-      "checksum": "411B962B96F53B49E75D856EBC93F618C5A3134D73620E23908350AE01DB4A2C",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-1/deny-self-approve_darwin_arm64.tar.gz",
+      "checksum": "E9FD78139C080BF907B4AB6A08285A220D9D54393BEE6CA22B709E7547955CAD",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-0/deny-self-approve_linux_amd64.tar.gz",
-      "checksum": "6CEA5CF8F58839EBBA56B0384B15E9A8E73C24571A529BD6D05CF3B6B4ACCEF8",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-1/deny-self-approve_linux_amd64.tar.gz",
+      "checksum": "8C8373D0A92D3C993D70812242EBA9B152E31323333D53F3020F9055BD9B7FB7",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-0/deny-self-approve_linux_arm64.tar.gz",
-      "checksum": "256FE6B915D130DDB64C7D266C3F890B2104FBC8F08878DDA97210595C005793",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-1/deny-self-approve_linux_arm64.tar.gz",
+      "checksum": "F613A28C67AAA77CDD6C36A60DAD3C3DF9FBE7A39D5BEB78FFA060C55DF49A49",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-0/deny-self-approve_windows_amd64.zip",
-      "checksum": "8A33C89C04B3E3251C0EC69B5C4F6B29DBDE324FC7785AA6938EE500E1821641",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-1/deny-self-approve_windows_amd64.zip",
+      "checksum": "BEFDBECC5716A4DBABC412D8165B7BA8267C8F84540C2ED8A700EE1E3069F230",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-0/deny-self-approve_windows_arm64.zip",
-      "checksum": "219CDC2A3D41F2EE8E70F521C7AA014BF22762D0BFBF224339696D41D7A7CE23",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-1/deny-self-approve_windows_arm64.zip",
+      "checksum": "97E5C7611BE550B62886E2E6E5BD68241CF69E1F89BB1B53BDA7557B196542C5",
       "algorithm": "sha256"
     },
     {

--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -1,33 +1,33 @@
 {
   "checksums": [
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-1/deny-self-approve_darwin_amd64.tar.gz",
-      "checksum": "54C244A4E654F5331669770860F74AD5B63949821DF52A0D16199B49504D0A13",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-2/deny-self-approve_darwin_amd64.tar.gz",
+      "checksum": "237AF657038118C8646C2D3BD208DCFAB27298F8FAEC1C528CF1EE99AE6ADFB7",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-1/deny-self-approve_darwin_arm64.tar.gz",
-      "checksum": "E9FD78139C080BF907B4AB6A08285A220D9D54393BEE6CA22B709E7547955CAD",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-2/deny-self-approve_darwin_arm64.tar.gz",
+      "checksum": "0BA9E831476F1FA1A1953F5C93FEB087AF21C457E8A7E8CA87B792FC9B1A1063",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-1/deny-self-approve_linux_amd64.tar.gz",
-      "checksum": "8C8373D0A92D3C993D70812242EBA9B152E31323333D53F3020F9055BD9B7FB7",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-2/deny-self-approve_linux_amd64.tar.gz",
+      "checksum": "18E472247B1DB1D261B13F715B69AE725911006953DE511B6F69EBE9DEAE7330",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-1/deny-self-approve_linux_arm64.tar.gz",
-      "checksum": "F613A28C67AAA77CDD6C36A60DAD3C3DF9FBE7A39D5BEB78FFA060C55DF49A49",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-2/deny-self-approve_linux_arm64.tar.gz",
+      "checksum": "5EC368103B424391819935603B972C2AD809500CB91B3E8B57078193F07C40E8",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-1/deny-self-approve_windows_amd64.zip",
-      "checksum": "BEFDBECC5716A4DBABC412D8165B7BA8267C8F84540C2ED8A700EE1E3069F230",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-2/deny-self-approve_windows_amd64.zip",
+      "checksum": "D6479D3EBF022638B497137A157666C33ECAFF411B38DD19F26F32314968AD05",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-1/deny-self-approve_windows_arm64.zip",
-      "checksum": "97E5C7611BE550B62886E2E6E5BD68241CF69E1F89BB1B53BDA7557B196542C5",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-2/deny-self-approve_windows_arm64.zip",
+      "checksum": "8D6E502391F85BDEF274005943C78C2B50A3A632B556CB52CDC9E18AE8AD7434",
       "algorithm": "sha256"
     },
     {

--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -1,33 +1,33 @@
 {
   "checksums": [
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-2/deny-self-approve_darwin_amd64.tar.gz",
-      "checksum": "237AF657038118C8646C2D3BD208DCFAB27298F8FAEC1C528CF1EE99AE6ADFB7",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-3/deny-self-approve_darwin_amd64.tar.gz",
+      "checksum": "9357D85B6B4EF973ACFACB357CBB584F671FE689A88266C24E2CA37D840E6476",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-2/deny-self-approve_darwin_arm64.tar.gz",
-      "checksum": "0BA9E831476F1FA1A1953F5C93FEB087AF21C457E8A7E8CA87B792FC9B1A1063",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-3/deny-self-approve_darwin_arm64.tar.gz",
+      "checksum": "2452C5F9A643F44FDB19CE71F3ED30F9C94191F9AC66D79D308B2F1A4F52D32E",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-2/deny-self-approve_linux_amd64.tar.gz",
-      "checksum": "18E472247B1DB1D261B13F715B69AE725911006953DE511B6F69EBE9DEAE7330",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-3/deny-self-approve_linux_amd64.tar.gz",
+      "checksum": "5E28B59A470AAACE0ABF817781DB55D6F02396A09EC79C5DB7D9DA5AD606280B",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-2/deny-self-approve_linux_arm64.tar.gz",
-      "checksum": "5EC368103B424391819935603B972C2AD809500CB91B3E8B57078193F07C40E8",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-3/deny-self-approve_linux_arm64.tar.gz",
+      "checksum": "395D715E59A9EA9F565113230699F18B61241C9D524279F36EDEAF1DE164ED17",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-2/deny-self-approve_windows_amd64.zip",
-      "checksum": "D6479D3EBF022638B497137A157666C33ECAFF411B38DD19F26F32314968AD05",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-3/deny-self-approve_windows_amd64.zip",
+      "checksum": "50E8288949C1714862118EA037B3AF4E249700B322DC5FB40662658CB2B0D05C",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-2/deny-self-approve_windows_arm64.zip",
-      "checksum": "8D6E502391F85BDEF274005943C78C2B50A3A632B556CB52CDC9E18AE8AD7434",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-3/deny-self-approve_windows_arm64.zip",
+      "checksum": "DD884651234BF74913AC01D931B197DAC2E4C4E20C8AD4260307B4E02D5F481D",
       "algorithm": "sha256"
     },
     {

--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -1,33 +1,33 @@
 {
   "checksums": [
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-3/deny-self-approve_darwin_amd64.tar.gz",
-      "checksum": "9357D85B6B4EF973ACFACB357CBB584F671FE689A88266C24E2CA37D840E6476",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3/deny-self-approve_darwin_amd64.tar.gz",
+      "checksum": "10109278D7129914172EB2BCECD67B0496E4FC452876E070A7D503201C78700C",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-3/deny-self-approve_darwin_arm64.tar.gz",
-      "checksum": "2452C5F9A643F44FDB19CE71F3ED30F9C94191F9AC66D79D308B2F1A4F52D32E",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3/deny-self-approve_darwin_arm64.tar.gz",
+      "checksum": "315D0E91EB3F02DA8AECD9F6CE2F953934A17019479449664F30BEAC11A14221",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-3/deny-self-approve_linux_amd64.tar.gz",
-      "checksum": "5E28B59A470AAACE0ABF817781DB55D6F02396A09EC79C5DB7D9DA5AD606280B",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3/deny-self-approve_linux_amd64.tar.gz",
+      "checksum": "28A47B83034A29D5B52EC8AF8203685BB89EEB9562A381A69170AB14EADC07B2",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-3/deny-self-approve_linux_arm64.tar.gz",
-      "checksum": "395D715E59A9EA9F565113230699F18B61241C9D524279F36EDEAF1DE164ED17",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3/deny-self-approve_linux_arm64.tar.gz",
+      "checksum": "96D7D7F9CD8BD88EC5FC7CE99F9FD168D6013977ABEEF3C71FCD993F382C9DF1",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-3/deny-self-approve_windows_amd64.zip",
-      "checksum": "50E8288949C1714862118EA037B3AF4E249700B322DC5FB40662658CB2B0D05C",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3/deny-self-approve_windows_amd64.zip",
+      "checksum": "8D9255B228EADFF7607A1DBCB92509DFFF7AF89746B15B5BA29D14E5EE70A5D1",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-3/deny-self-approve_windows_arm64.zip",
-      "checksum": "DD884651234BF74913AC01D931B197DAC2E4C4E20C8AD4260307B4E02D5F481D",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3/deny-self-approve_windows_arm64.zip",
+      "checksum": "253FEA59B0207ED0916AA63F1F46BEE3DFA7DA1CBC8C984940D359CFDDF39469",
       "algorithm": "sha256"
     },
     {

--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -1,33 +1,33 @@
 {
   "checksums": [
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.2/deny-self-approve_darwin_amd64.tar.gz",
-      "checksum": "053C56411AFFBD136142CFD8E8EB5F5A7FACB676D862D244F1D8A425FB868E85",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-0/deny-self-approve_darwin_amd64.tar.gz",
+      "checksum": "2B8C90B2FCEAC7E5D6E4B472CE33DD8298AA60AE4EEADDBEDE2EC045D93BDF59",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.2/deny-self-approve_darwin_arm64.tar.gz",
-      "checksum": "1F723E0533895A8668585909242E8F99EB6A25A2DFC1D919CAAC29B0BC4E3E44",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-0/deny-self-approve_darwin_arm64.tar.gz",
+      "checksum": "411B962B96F53B49E75D856EBC93F618C5A3134D73620E23908350AE01DB4A2C",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.2/deny-self-approve_linux_amd64.tar.gz",
-      "checksum": "1335D20398765284B7B6F550C2A2595C66851BE119E045D1CF958D7897EEA0F4",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-0/deny-self-approve_linux_amd64.tar.gz",
+      "checksum": "6CEA5CF8F58839EBBA56B0384B15E9A8E73C24571A529BD6D05CF3B6B4ACCEF8",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.2/deny-self-approve_linux_arm64.tar.gz",
-      "checksum": "4E114BDB74C5D72E935FC061F80612DD382C50A177C4E10070D12B42069B83D2",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-0/deny-self-approve_linux_arm64.tar.gz",
+      "checksum": "256FE6B915D130DDB64C7D266C3F890B2104FBC8F08878DDA97210595C005793",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.2/deny-self-approve_windows_amd64.zip",
-      "checksum": "96800EAFFBB9912DA4FBB020DF08481FC274C09CAF2154CDB054FB9DAD2860E9",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-0/deny-self-approve_windows_amd64.zip",
+      "checksum": "8A33C89C04B3E3251C0EC69B5C4F6B29DBDE324FC7785AA6938EE500E1821641",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.2/deny-self-approve_windows_arm64.zip",
-      "checksum": "4245E59BBF1CD7AD5012B703361B6113172D03B02427C3A0F84C406925CD2E16",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.3-0/deny-self-approve_windows_arm64.zip",
+      "checksum": "219CDC2A3D41F2EE8E70F521C7AA014BF22762D0BFBF224339696D41D7A7CE23",
       "algorithm": "sha256"
     },
     {

--- a/aqua/imports/deny-self-approve.yaml
+++ b/aqua/imports/deny-self-approve.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: suzuki-shunsuke/deny-self-approve@v0.2.3-1
+  - name: suzuki-shunsuke/deny-self-approve@v0.2.3-2

--- a/aqua/imports/deny-self-approve.yaml
+++ b/aqua/imports/deny-self-approve.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: suzuki-shunsuke/deny-self-approve@v0.2.3-0
+  - name: suzuki-shunsuke/deny-self-approve@v0.2.3-1

--- a/aqua/imports/deny-self-approve.yaml
+++ b/aqua/imports/deny-self-approve.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: suzuki-shunsuke/deny-self-approve@v0.2.2
+  - name: suzuki-shunsuke/deny-self-approve@v0.2.3-0

--- a/aqua/imports/deny-self-approve.yaml
+++ b/aqua/imports/deny-self-approve.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: suzuki-shunsuke/deny-self-approve@v0.2.3-2
+  - name: suzuki-shunsuke/deny-self-approve@v0.2.3-3

--- a/aqua/imports/deny-self-approve.yaml
+++ b/aqua/imports/deny-self-approve.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: suzuki-shunsuke/deny-self-approve@v0.2.3-3
+  - name: suzuki-shunsuke/deny-self-approve@v0.2.3


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/deny-self-approve/pull/81 Fix a panic if a pull request includes commits not linked to a GitHub User
- Add an output `has_not_linked_commit` and improve the error message