### PR TITLE
fix: update deny-self-approve to v0.3.0-0 and stop dismissing approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,7 @@
 [![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/suzuki-shunsuke/deny-self-approve-action/main/LICENSE) | [action.yaml](action.yaml)
 
 GitHub Action to deny self approval using [deny-self-approve](https://github.com/suzuki-shunsuke/deny-self-approve).
-
-This action prevents pull requests' self-approvals by dimissing approvals from people who pushed commits to pull requests.
-This action fails if no one who didn't push commits to the pull request approves the pull request.
-This action uses [deny-self-approve](https://github.com/suzuki-shunsuke/deny-self-approve).
+For details, please see [deny-self-approve](https://github.com/suzuki-shunsuke/deny-self-approve).
 
 ## How To Use
 
@@ -37,20 +34,15 @@ jobs:
 ```
 
 A pull request can't be merged until someone approves the pull request because the job is required.
-When someone who pushed commits to the pull request approves the pull request, this workflow is triggered and self-approval is dismissed and the job fails.
-The pull request can't be merged because the required job fails and the self-approval is dismissed.
-If someone who doesn't push any commit to the pull request approves the pull request, the workflow is triggered and the job passes. Then the pull request can be merged.
+When someone who pushed commits to the pull request approves the pull request, this workflow is triggered and the job fails.
+The pull request can't be merged because the required job fails.
+If someone who doesn't push any commit to the pull request approves the pull request, the workflow is triggered and the job passes.
+Then the pull request can be merged.
 That's how this action prevents self-approval.
 
 ### 2. Run this action via **merge_group** events
 
 Please add the job `check-approval` to required checks.
-
-> [!WARNING]
-> Unfortunately, seems like we need to add the job `check-approval` to required checks.
-> We thought pull requests weren't merged by dismissing self-approvals.
-> But actually pull requests were merged even if self-approvals were dismissed.
-> Maybe this is a bug of GitHub.
 
 ```yaml
 name: Check approval

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     permissions:
-      pull-requests: write # To dismiss self-approvals
       contents: read # To list commits in pull requests
     steps:
       - uses: suzuki-shunsuke/deny-self-approve-action@85a0ec0a189b083a84a95d37766f6f6df5aea1ba # v0.1.0

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
     - run: |
         tempfile=$(mktemp)
         echo "has_not_linked_commit=false" >> "$GITHUB_OUTPUT"
-        if ! deny-self-approve validate --dismiss 2> >(tee -a "$tempfile" >&2); then
+        if ! deny-self-approve validate 2> >(tee -a "$tempfile" >&2); then
           if grep -q "commit isn't linked to a GitHub User" "$tempfile"; then
             echo "::error:: Commit isn't linked to a GitHub User. https://github.com/suzuki-shunsuke/deny-self-approve/blob/main/docs/001.md" >&2
             echo "has_not_linked_commit=true" >> "$GITHUB_OUTPUT"

--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -1,39 +1,39 @@
 {
   "checksums": [
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0-0/deny-self-approve_darwin_amd64.tar.gz",
-      "checksum": "8F055B0862490F8A24FE83F4FF38CFC83A3542AEF1421A2E5B970FBEFE842F8B",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0/deny-self-approve_darwin_amd64.tar.gz",
+      "checksum": "46877DFF2719318D940D617D7D67C6CD3A82C98D84D5A99F653E6AFA8544F57B",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0-0/deny-self-approve_darwin_arm64.tar.gz",
-      "checksum": "A2E42E6922E7216E1F5F86AFE78EE55D753E65D31E8C70E5F436C8D2F6A114B5",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0/deny-self-approve_darwin_arm64.tar.gz",
+      "checksum": "11C6A204C23E35C8864332BCD3CC564A3B6F57C402F996F11085BD01568FD203",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0-0/deny-self-approve_linux_amd64.tar.gz",
-      "checksum": "C7C42F0392AF0E130473832E963EF7E7FBA5AE95DE810A96030C83E59A26A2D0",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0/deny-self-approve_linux_amd64.tar.gz",
+      "checksum": "C6C46279DA8E10D147AEF5DFDC8F988D33A6418978B9931AA3C8D3D1D5CB399B",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0-0/deny-self-approve_linux_arm64.tar.gz",
-      "checksum": "9C16B20AC653D2CC47D966B11044C27693E5BFB7D9DF56D4FD738F77E484B24C",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0/deny-self-approve_linux_arm64.tar.gz",
+      "checksum": "CA8F4F867965ABF93D3C4B101072223048048E994A753CDF93DB7B89136BF571",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0-0/deny-self-approve_windows_amd64.zip",
-      "checksum": "779F2285EDF96A20D5A235789F1D0D4EB631D890C0325E117964213A71B0EDC9",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0/deny-self-approve_windows_amd64.zip",
+      "checksum": "E9FDCB1E4B2808E9A74F9F5D6F6E83DD31746DD7BA77A621CACC32A21296D78F",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0-0/deny-self-approve_windows_arm64.zip",
-      "checksum": "6A0A5419E569072B7E949CA799752EFF5C5748717FACE07F147DFC20E0C91093",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0/deny-self-approve_windows_arm64.zip",
+      "checksum": "B229BE2A4CFF0FE7DD5ED3A5EF6343A17B469B8078D2E6AC3A299337C6ED3C65",
       "algorithm": "sha256"
     },
     {
-      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.316.0/registry.yaml",
-      "checksum": "0A6859BD65207F041725E945481F4E7C649AFD8C22EBCA698535B0321C81127A1732246BE7C7F9630EF520B060248495A709CE7DFD01FA81CB3FA4D4D3E9A730",
-      "algorithm": "sha512"
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.321.0/registry.yaml",
+      "checksum": "C79F9CFF22E885E78842B1CD83903B0063C250B49817F61C5D33D2BA5E0342A5",
+      "algorithm": "sha256"
     }
   ]
 }

--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -1,33 +1,33 @@
 {
   "checksums": [
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.4/deny-self-approve_darwin_amd64.tar.gz",
-      "checksum": "EF29506C8C9FDB7A8132A9BB280ED66207EEA55F21BCEAFF867A06972CFCCDF4",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0-0/deny-self-approve_darwin_amd64.tar.gz",
+      "checksum": "8F055B0862490F8A24FE83F4FF38CFC83A3542AEF1421A2E5B970FBEFE842F8B",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.4/deny-self-approve_darwin_arm64.tar.gz",
-      "checksum": "CD8406BEEBB1F118F631D33AE54FBDB86F20528938CFAFD03D071925F2F6DA2B",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0-0/deny-self-approve_darwin_arm64.tar.gz",
+      "checksum": "A2E42E6922E7216E1F5F86AFE78EE55D753E65D31E8C70E5F436C8D2F6A114B5",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.4/deny-self-approve_linux_amd64.tar.gz",
-      "checksum": "B5DB07F2A33ACF0EED4379B4B808D5E3C68E9FF8E1386630631737941E5ACD06",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0-0/deny-self-approve_linux_amd64.tar.gz",
+      "checksum": "C7C42F0392AF0E130473832E963EF7E7FBA5AE95DE810A96030C83E59A26A2D0",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.4/deny-self-approve_linux_arm64.tar.gz",
-      "checksum": "0D4A8A10B2953626B096D9695AF380C91F6B41DCB6D2FBDF9FF490F369BF50B4",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0-0/deny-self-approve_linux_arm64.tar.gz",
+      "checksum": "9C16B20AC653D2CC47D966B11044C27693E5BFB7D9DF56D4FD738F77E484B24C",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.4/deny-self-approve_windows_amd64.zip",
-      "checksum": "D4D82821E923C50D818EFE7317214A0EFC5A56E152AC21453E04E20A380F84BE",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0-0/deny-self-approve_windows_amd64.zip",
+      "checksum": "779F2285EDF96A20D5A235789F1D0D4EB631D890C0325E117964213A71B0EDC9",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.2.4/deny-self-approve_windows_arm64.zip",
-      "checksum": "02070B072BDFD3AA8255A9DCF4E30A8A89CA933DE966CB50C9270F70A760EDC0",
+      "id": "github_release/github.com/suzuki-shunsuke/deny-self-approve/v0.3.0-0/deny-self-approve_windows_arm64.zip",
+      "checksum": "6A0A5419E569072B7E949CA799752EFF5C5748717FACE07F147DFC20E0C91093",
       "algorithm": "sha256"
     },
     {

--- a/aqua/aqua.yaml
+++ b/aqua/aqua.yaml
@@ -7,5 +7,5 @@ checksum:
   require_checksum: true
 registries:
 - type: standard
-  ref: v4.316.0  # renovate: depName=aquaproj/aqua-registry
+  ref: v4.321.0 # renovate: depName=aquaproj/aqua-registry
 import_dir: imports

--- a/aqua/imports/deny-self-approve.yaml
+++ b/aqua/imports/deny-self-approve.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: suzuki-shunsuke/deny-self-approve@v0.3.0-0
+  - name: suzuki-shunsuke/deny-self-approve@v0.3.0

--- a/aqua/imports/deny-self-approve.yaml
+++ b/aqua/imports/deny-self-approve.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: suzuki-shunsuke/deny-self-approve@v0.2.4
+  - name: suzuki-shunsuke/deny-self-approve@v0.3.0-0


### PR DESCRIPTION
Update deny-self-approve to [v0.3.0-0](https://github.com/suzuki-shunsuke/deny-self-approve/releases/tag/v0.3.0-0).

# ⚠️ Breaking Changes

- This action doesn't dismiss approvals anymore
- This action succeeds if multiple people approve the pull request